### PR TITLE
[IOS] Crash Due to exc_bad_access (code=1 address=0x0) & Android return path instead of URI

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,18 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="io.github.elyx0.reactnativedocumentpicker">
-
-  <application>
-
-    <provider
-      android:name="androidx.core.content.FileProvider"
-      android:authorities="${applicationId}.provider"
-      android:exported="false"
-      android:grantUriPermissions="true">
-      <meta-data
-        android:name="android.support.FILE_PROVIDER_PATHS"
-        android:resource="@xml/provider_paths" />
-    </provider>
-  </application>
-
 </manifest>

--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -178,14 +178,12 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 	private WritableMap getMetadata(Uri uri) {
 		WritableMap map = Arguments.createMap();
 
-    System.out.println("CEKK URI STRING " + uri.toString());
     String path = uri.getPath().toString();
     try {
       path = RealPathUtil.getRealPathFromURI(getReactApplicationContext(), uri);
     } catch (Exception err) {
       Log.e("ERR_GET_PATH", err.toString());
     }
-    System.out.println("CEKK URI STRING " + path);
     map.putString(FIELD_URI, "file://"+path);
 
 		// TODO vonovak - FIELD_FILE_COPY_URI is implemented on iOS only (copyTo) settings

--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -100,7 +100,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 		this.promise = promise;
 
 		try {
-			Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+			Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
 			intent.addCategory(Intent.CATEGORY_OPENABLE);
 
 			intent.setType("*/*");

--- a/android/src/main/res/xml/provider_paths.xml
+++ b/android/src/main/res/xml/provider_paths.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-path name="external_files" path="."/>
-</paths>


### PR DESCRIPTION
**[EDITED]**

**[IOS]**
Hello, I'm facing a crash issue in IOS Document Picker. When I'm trying to debug this crash related to the **"exc_bad_access (code=1 address=0x0)"** this issue happens when the user taps the file multiple times.
After a few times of trying to debug, I think it because the **resolve** object expired or not exist anymore.

In my case, my user thinks the app not responding when select file in GDrive so they tap multiple times, but it actually works. Just need a few times to complete the process. So when a new tap exist the old **resolve** object deleted, then crash happened.

In this pull request, I add code to check the **resolve** object null or not, when a new tap happened.

Hope it can help,

**[Android]**
I also facing this issue recently, I cannot really access the android URI in react-native-fs. Some Uri required me to decode first but also does not make the Uri is accessible.
here the uri example: **"content://com.android.providers.downloads.documents/document/raw%3A%2Fstorage%2Femulated%2F0%2FDownload%2Fadmob.docx"**  some of backlash "**/**" become "**%2F**", and different devices have different Uri issue. 

So in this PR, I add code to get Real Path, then I change Uri response to Real Path.

Oh ya, I'm using getRealPath module from here react-native-image-crop-picker (https://github.com/ivpusic/react-native-image-crop-picker/blob/master/android/src/main/java/com/reactnative/ivpusic/imagepicker/RealPathUtil.java)

Thanks.