### PR TITLE
Fix allFiles on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The type or types of documents to allow selection of. May be an array of types a
 
 - On Android these are MIME types such as `text/plain` or partial MIME types such as `image/*`. See [common MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
 - On iOS these must be Apple "[Uniform Type Identifiers](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html)"
-- If `type` is omitted it will be treated as `*/*` or `public.content`.
+- If `type` is omitted it will be treated as `*/*` or `public.item`.
 - Multiple type strings are not supported on Android before KitKat (API level 19), Jellybean will fall back to `*/*` if you provide an array with more than one value.
 
 ##### [iOS only] `copyTo`:`"cachesDirectory" | "documentDirectory"`:
@@ -101,7 +101,7 @@ The base64 encoded content of the picked file if the option `readContent` was se
 
 `DocumentPicker.types.*` provides a few common types for use as `type` values, these types will use the correct format for each platform (MIME types on Android, UTIs on iOS).
 
-- `DocumentPicker.types.allFiles`: All document types, on Android this is `*/*`, on iOS is `public.content` (note that some binary and archive types do not inherit from `public.content`)
+- `DocumentPicker.types.allFiles`: All document types, on Android this is `*/*`, on iOS is `public.item`
 - `DocumentPicker.types.images`: All image types (`image/*` or `public.image`)
 - `DocumentPicker.types.plainText`: Plain text files ie: `.txt` (`text/plain` or `public.plain-text`)
 - `DocumentPicker.types.audio`: All audio types (`audio/*` or `public.audio`)

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare module 'react-native-document-picker' {
       zip: 'application/zip';
     };
     utis: {
-      allFiles: 'public.content';
+      allFiles: 'public.item';
       audio: 'public.audio';
       csv: 'public.comma-separated-values-text';
       doc: 'com.microsoft.word.doc';

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ const Types = {
     zip: 'application/zip',
   },
   utis: {
-    allFiles: 'public.content',
+    allFiles: 'public.item',
     audio: 'public.audio',
     csv: 'public.comma-separated-values-text',
     doc: 'com.microsoft.word.doc',


### PR DESCRIPTION
As said in #342, the wrong type is used for allFiles. .zip files (and many others) cannot be used.
Using public.item, since both public.content and public.data must conform to public.item. 