### PR TITLE
chore: introduce GH discussions

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -23,20 +23,6 @@ actions:
     unlock: true
     open: true
 
-  question:
-    # Post a comment
-    comment: >
-      :wave: @{issue-author}, thanks for opening the issue. The issue tracker is intended for tracking bug reports and feature requests only. 
-
-      Seems you have a usage question. Please ask the question on [StackOverflow](https://stackoverflow.com/questions/tagged/react-native). You can also chat with other community members on [Reactiflux Discord server](https://www.reactiflux.com/).
-    # Lock the thread
-    lock: true
-    close: true
-  # Actions taken when the `repro-required` label is removed
-  -question:
-    # Unlock the thread
-    unlock: true
-    open: true
 # Limit to only `issues` or `pulls`
 # only: issues
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # react-native-document-picker
 
-⚠️ NOTE: since version 3.3.2 we're using git version tags prefixed with `v`, eg. `v3.3.2`. This is a standard format and should mean no changes to your workflows.
+⚠️ NOTE: if you want to ask questions, we opened [GH discussions](https://github.com/rnmods/react-native-document-picker/discussions) for that purpose! 🤗 Issue tracker is now reserved for bugs only and issues not following the issue template will be closed. Thank you!
 
+⚠️ NOTE: since version 3.3.2 we're using git version tags prefixed with `v`, eg. `v3.3.2`. This is a standard format and should mean no changes to your workflows.
 
 A React Native wrapper for:
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

motivation: I'd like people who are asking questions to use GH discussions instead of issues in the issue tracker. Issue tracker will be used solely for bugs now.

## Test Plan

discussions are available in top menu
