### PR TITLE
[Windows] Implementing Folder Picker support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,7 @@ declare module 'react-native-document-picker' {
       xls: '.xls';
       xlsx: '.xlsx';
       zip: '.zip .gz';
+      folder: 'folder';
     };
   };
   type PlatformTypes = {

--- a/index.js
+++ b/index.js
@@ -62,12 +62,10 @@ function pick(opts) {
     );
   }
 
-  //Make sure If user selects folder option 
-  
   if (Array.isArray(opts.type) && opts.type.length > 1) {
-    if(opts.type.includes('folder')){
+    if (opts.type.includes('folder')) {
       throw new TypeError(
-        'When `type` array is `folder` then other options are not supported.'
+        'When type array is folder then other options are not supported.'
       );
     }
   }

--- a/index.js
+++ b/index.js
@@ -62,6 +62,16 @@ function pick(opts) {
     );
   }
 
+  //Make sure If user selects folder option 
+  
+  if (Array.isArray(opts.type) && opts.type.length > 1) {
+    if(opts.type.includes('folder')){
+      throw new TypeError(
+        'When `type` array is `folder` then other options are not supported.'
+      );
+    }
+  }
+
   if ('mode' in opts && !['import', 'open'].includes(opts.mode)) {
     throw new TypeError('Invalid mode option: ' + opts.mode);
   }
@@ -140,6 +150,7 @@ const Types = {
     xls: '.xls',
     xlsx: '.xlsx',
     zip: '.zip .gz',
+    folder: 'folder',
   },
 };
 

--- a/index.js
+++ b/index.js
@@ -64,9 +64,7 @@ function pick(opts) {
 
   if (Array.isArray(opts.type) && opts.type.length > 1) {
     if (opts.type.includes('folder')) {
-      throw new TypeError(
-        'When type array is folder then other options are not supported.'
-      );
+      throw new TypeError('When type array is folder then other options are not supported');
     }
   }
 


### PR DESCRIPTION
[Windows only] Adding windows folder picker support into react-native-document-picker

NPM module react-native-document-picker was not having support for Windows Folder picker feature. 
As part of this PR I have implemented this feature. Windows natively provides Folder picker option, similar to Document Picker.  App which require File picker more chances that Folder pick option will also be used, hence its good to provide this feature as well.

This feature is added only for the Windows OS.
