### PR TITLE
Fix crash on iOS

### DIFF
--- a/ios/RNDocumentPicker/RNDocumentPicker.m
+++ b/ios/RNDocumentPicker/RNDocumentPicker.m
@@ -208,6 +208,11 @@ RCT_EXPORT_METHOD(releaseSecureAccess:(NSArray<NSString *> *)uris)
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
 {
     RCTPromiseResolveBlock resolve = [composeResolvers lastObject];
+
+    if (resolve == nil) {
+        return;
+    }
+
     RCTPromiseRejectBlock reject = [composeRejecters lastObject];
     [composeResolvers removeLastObject];
     [composeRejecters removeLastObject];


### PR DESCRIPTION

# Summary

See issue: https://github.com/rnmods/react-native-document-picker/issues/276


## Test Plan

- Open app
- Open Picker
- Fast double tap pdf document

**Actual**: app freezes and/or creashes.



### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |        |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
