### PR TITLE
support only android >=5 (API 21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,16 @@ A React Native wrapper for:
 - Android's `Intent.ACTION_GET_CONTENT`
 - Windows `Windows.Storage.Pickers`
 
+Requires Android 5.0+ and iOS 10+
+
 ### Installation
 
 ```bash
 npm i --save react-native-document-picker
+
+OR
+
+yarn add react-native-document-picker
 ```
 
 You need to enable iCloud Documents to access iCloud
@@ -45,7 +51,6 @@ The type or types of documents to allow selection of. May be an array of types a
 - On Android these are MIME types such as `text/plain` or partial MIME types such as `image/*`. See [common MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
 - On iOS these must be Apple "[Uniform Type Identifiers](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html)"
 - If `type` is omitted it will be treated as `*/*` or `public.item`.
-- Multiple type strings are not supported on Android before KitKat (API level 19), Jellybean will fall back to `*/*` if you provide an array with more than one value.
 
 ##### [iOS only] `mode`:`"import" | "open"`:
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ android {
     buildToolsVersion safeExtGet("buildToolsVersion", '28.0.3')
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)
     }
 

--- a/react-native-document-picker.podspec
+++ b/react-native-document-picker.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.authors         = package['author']
   s.source          = { :git => "https://github.com/Elyx0/react-native-document-picker", :tag => "v#{s.version}" }
   s.source_files    = "ios/RNDocumentPicker/*.{h,m}"
-  s.platform        = :ios, "9.0"
+  s.platform        = :ios, "10.0"
   s.dependency        'React-Core'
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

motivation: RN itself now supports only android 5+ and we can simplify our code a little bit thanks to that. 


also closes #317

## Test Plan

tested on android devices v6 and v10


### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
