### PR TITLE
Fix copyFile on Android.

### DIFF
--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -265,8 +265,9 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 				if (in != null) {
 					out = new FileOutputStream(destFile);
 					byte[] buffer = new byte[1024];
-					while (in.read(buffer) > 0) {
-						out.write(buffer);
+					int len;
+					while ((len = in.read(buffer)) > 0) {
+						out.write(buffer, 0, len);
 					}
 					out.close();
 					in.close();


### PR DESCRIPTION
`copyFile` method is incorrect for Android (haven't checked iOS as I'm not familiar with it).

`InputStream.read` returns the number of bytes read, it may be that only a few bytes are read but the `OutputStream.write` method with one argument always writes the whole buffer even if only the first few bytes are set.