### PR TITLE
When using copyTo on android put the file in a uniquely named directory

### DIFF
--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * @see <a href="https://developer.android.com/guide/topics/providers/document-provider.html">android documentation</a>
@@ -239,6 +240,9 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 				if (copyTo.equals("documentDirectory")) {
 					dir = context.getFilesDir();
 				}
+				// we don't want to rename the file so we put it into a unique location
+				dir = new File(dir, UUID.randomUUID().toString());
+				dir.mkdir();
 				String fileName = map.getString(FIELD_NAME);
 				if (fileName == null) {
 					fileName = String.valueOf(System.currentTimeMillis());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-document-picker",
-  "version": "5.0.1",
+  "version": "5.0.0",
   "description": "A react native interface to access Documents from dropbox google drive, iCloud",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-document-picker",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A react native interface to access Documents from dropbox google drive, iCloud",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

If you use `copyTo: 'cachesDirectory'` on Android, it copies the file directly into the cache directory. If there is a file already in there with the same name, it is overwritten. This is different to the behaviour on iOS, where the file is put into a uniquely named sub-directory to ensure it is not overwritten.

I have modified the Android code to take the same approach as on iOS

## Test Plan

Configure the picker with  `copyTo: 'cachesDirectory'.`
Open picker on android, select file and then log the `fileCopyUri` 
It will contain a unique subdirectory, i.e. `/data/user/0/[APPID]/cache/[UUID]/[FILENAME]`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |       Already Implemented   |
| Android |    ✅    |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
