### PR TITLE
feat(ios): listen to user dismiss via swipe down

### DIFF
--- a/ios/RNDocumentPicker/RNDocumentPicker.m
+++ b/ios/RNDocumentPicker/RNDocumentPicker.m
@@ -20,7 +20,7 @@ static NSString *const FIELD_NAME = @"name";
 static NSString *const FIELD_TYPE = @"type";
 static NSString *const FIELD_SIZE = @"size";
 
-@interface RNDocumentPicker () <UIDocumentPickerDelegate>
+@interface RNDocumentPicker () <UIDocumentPickerDelegate, UIAdaptivePresentationControllerDelegate>
 @end
 
 @implementation RNDocumentPicker {
@@ -74,6 +74,7 @@ RCT_EXPORT_METHOD(pick:(NSDictionary *)options
     NSArray *allowedUTIs = [RCTConvert NSArray:options[OPTION_TYPE]];
     UIDocumentPickerViewController *documentPicker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:(NSArray *)allowedUTIs inMode:mode];
     documentPicker.delegate = self;
+    documentPicker.presentationController.delegate = self;
     documentPicker.modalPresentationStyle = UIModalPresentationFormSheet;
     
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
@@ -233,6 +234,15 @@ RCT_EXPORT_METHOD(releaseSecureAccess:(NSArray<NSString *> *)uris)
 }
 
 - (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)controller
+{
+    [self rejectLastSelection];
+}
+
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+    [self rejectLastSelection];
+}
+
+- (void)rejectLastSelection
 {
     RCTPromiseRejectBlock reject = [composeRejecters lastObject];
     [composeResolvers removeLastObject];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Modals on iOS can also be dismissed via user gesture (swiping the modal down).

This PR adds also a listener for that usecase and throws the same error as it would on canceling via cancel button.

closes #364 

## Test Plan

Tested on iOS device.

### What's required for testing (prerequisites)?

iOS Device

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
