### PR TITLE
Android: add pickDirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ The file size of the document. _On Android some DocumentProviders may not provid
 
 The base64 encoded content of the picked file if the option `readContent` was set to `true`.
 
+
+#### [Android only] `DocumentPicker.pickDirectory(options)`
+
+Open a system directory picker. Returns a promise that resolves to the directory selected by user.
+
+### Result
+
+##### `uri`:
+
+The URI of the selected directory. Usually it will be a content URI.
+
+##### `path`:
+
+Actual path to the selected directory. May not be set if the dir picker could not translate the URI to a path.
+
+
 ### `DocumentPicker.types.*`
 
 `DocumentPicker.types.*` provides a few common types for use as `type` values, these types will use the correct format for each platform (MIME types on Android, UTIs on iOS).

--- a/README.md
+++ b/README.md
@@ -118,10 +118,6 @@ Open a system directory picker. Returns a promise that resolves to the directory
 
 The URI of the selected directory. Usually it will be a content URI.
 
-##### `path`:
-
-Actual path to the selected directory. May not be set if the dir picker could not translate the URI to a path.
-
 
 ### `DocumentPicker.types.*`
 

--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -9,10 +9,8 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.OpenableColumns;
-import android.util.Log;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
@@ -63,7 +61,6 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 	private static final String FIELD_NAME = "name";
 	private static final String FIELD_TYPE = "type";
 	private static final String FIELD_SIZE = "size";
-	private static final String FIELD_PATH = "path";
 
 
 	private final ActivityEventListener activityEventListener = new BaseActivityEventListener() {
@@ -217,35 +214,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 
 		WritableMap map = Arguments.createMap();
 		map.putString(FIELD_URI, uri.toString());
-		map.putString(FIELD_PATH, uriToPath(uri));
 		promise.resolve(map);
-	}
-
-	private String uriToPath(Uri uri) {
-		if (ContentResolver.SCHEME_FILE.equals(uri.getScheme())) {
-			File file = new File(uri.getPath());
-			return file.getName();
-		} else if (ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
-			String name = null;
-
-			// URI examples
-			// internal: content://com.android.externalstorage.documents/tree/primary%3Atest
-			// sd card:  content://com.android.externalstorage.documents/tree/1DEA-0313%3Atest
-			List<String> pathSegments = uri.getPathSegments();
-			if (pathSegments.get(0).equalsIgnoreCase("tree")) {
-				String[] parts = pathSegments.get(1).split(":", 2);
-				if (parts[0].equalsIgnoreCase("primary")) {
-					name = new File(Environment.getExternalStorageDirectory(), parts[1]).getAbsolutePath();
-				} else {
-					name = "/storage/" + parts[0] + "/" + parts[1];
-				}
-			}
-			Log.d(NAME, "Resolved content URI " + uri + " to path " + name);
-			return name;
-		} else {
-			Log.w(NAME, "Unknown URI scheme: " + uri.getScheme());
-			return null;
-		}
 	}
 
 	private static class ProcessDataTask extends GuardedResultAsyncTask<ReadableArray> {

--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -73,9 +73,9 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 				return;
 			}
 			if (requestCode == READ_REQUEST_CODE) {
-					onShowActivityResult(resultCode, data, promise);
+				onShowActivityResult(resultCode, data, promise);
 			} else if (requestCode == PICK_DIR_REQUEST_CODE) {
-					onPickDirectoryResult(resultCode, data, promise);
+				onPickDirectoryResult(resultCode, data, promise);
 			}
 		}
 	};

--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -51,7 +51,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 	private static final String E_UNEXPECTED_EXCEPTION = "UNEXPECTED_EXCEPTION";
 
 	private static final String OPTION_TYPE = "type";
-	private static final String OPTION_MULIPLE = "multiple";
+	private static final String OPTION_MULTIPLE = "multiple";
 	private static final String OPTION_COPYTO = "copyTo";
 
 	private static final String FIELD_URI = "uri";
@@ -126,7 +126,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 				}
 			}
 
-			boolean multiple = !args.isNull(OPTION_MULIPLE) && args.getBoolean(OPTION_MULIPLE);
+			boolean multiple = !args.isNull(OPTION_MULTIPLE) && args.getBoolean(OPTION_MULTIPLE);
 			intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple);
 
 			currentActivity.startActivityForResult(Intent.createChooser(intent, null), READ_REQUEST_CODE, Bundle.EMPTY);

--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -218,11 +218,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 
 		WritableMap map = Arguments.createMap();
 		map.putString(FIELD_URI, uri.toString());
-
-		String path = uriToPath(uri);
-		if (path != null) {
-			map.putString(FIELD_PATH, path);
-		}
+		map.putString(FIELD_PATH, uriToPath(uri));
 		promise.resolve(map);
 	}
 

--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -69,14 +69,13 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 	private final ActivityEventListener activityEventListener = new BaseActivityEventListener() {
 		@Override
 		public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+			if (promise == null) {
+				return;
+			}
 			if (requestCode == READ_REQUEST_CODE) {
-				if (promise != null) {
 					onShowActivityResult(resultCode, data, promise);
-				}
 			} else if (requestCode == PICK_DIR_REQUEST_CODE) {
-				if (promise != null) {
 					onPickDirectoryResult(resultCode, data, promise);
-				}
 			}
 		}
 	};

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,6 @@ declare module 'react-native-document-picker' {
     ): Promise<DocumentPickerResponse[]>;
     static isCancel<IError extends { code?: string }>(err?: IError): boolean;
     static releaseSecureAccess(uris: Array<string>): void;    
-    static pickDirectory(): Promise<DirectoryPickerResponse>;
+    static pickDirectory(): Promise<DirectoryPickerResponse> | null;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,6 +92,7 @@ declare module 'react-native-document-picker' {
       options: DocumentPickerOptions<OS>
     ): Promise<DocumentPickerResponse[]>;
     static isCancel<IError extends { code?: string }>(err?: IError): boolean;
+    static releaseSecureAccess(uris: Array<string>): void;    
     static pickDirectory(): Promise<DirectoryPickerResponse>;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,7 @@ declare module 'react-native-document-picker' {
   }
   interface DirectoryPickerResponse {
     uri: string;
-    path?: string;
+    path: string | null;
   }
   type Platform = 'ios' | 'android' | 'windows';
   export default class DocumentPicker<OS extends keyof PlatformTypes = Platform> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -78,6 +78,10 @@ declare module 'react-native-document-picker' {
     name: string;
     size: number;
   }
+  interface DirectoryPickerResponse {
+    uri: string,
+    path?: string
+  }
   type Platform = 'ios' | 'android' | 'windows';
   export default class DocumentPicker<OS extends keyof PlatformTypes = Platform> {
     static types: PlatformTypes['ios'] | PlatformTypes['android'] | PlatformTypes['windows'];
@@ -88,6 +92,6 @@ declare module 'react-native-document-picker' {
       options: DocumentPickerOptions<OS>
     ): Promise<DocumentPickerResponse[]>;
     static isCancel<IError extends { code?: string }>(err?: IError): boolean;
-    static releaseSecureAccess(uris: Array<string>): void;
+    static pickDirectory(): Promise<DirectoryPickerResponse>
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -79,8 +79,8 @@ declare module 'react-native-document-picker' {
     size: number;
   }
   interface DirectoryPickerResponse {
-    uri: string,
-    path?: string
+    uri: string;
+    path?: string;
   }
   type Platform = 'ios' | 'android' | 'windows';
   export default class DocumentPicker<OS extends keyof PlatformTypes = Platform> {
@@ -92,6 +92,6 @@ declare module 'react-native-document-picker' {
       options: DocumentPickerOptions<OS>
     ): Promise<DocumentPickerResponse[]>;
     static isCancel<IError extends { code?: string }>(err?: IError): boolean;
-    static pickDirectory(): Promise<DirectoryPickerResponse>
+    static pickDirectory(): Promise<DirectoryPickerResponse>;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ declare module 'react-native-document-picker' {
   interface DirectoryPickerResponse {
     uri: string;
   }
-  
+
   type Platform = 'ios' | 'android' | 'windows';
   export default class DocumentPicker<OS extends keyof PlatformTypes = Platform> {
     static types: PlatformTypes['ios'] | PlatformTypes['android'] | PlatformTypes['windows'];

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,6 @@ declare module 'react-native-document-picker' {
     ): Promise<DocumentPickerResponse[]>;
     static isCancel<IError extends { code?: string }>(err?: IError): boolean;
     static releaseSecureAccess(uris: Array<string>): void;
-    static pickDirectory(): Promise<DirectoryPickerResponse> | null;
+    static pickDirectory(): Promise<DirectoryPickerResponse | null>;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,7 +92,7 @@ declare module 'react-native-document-picker' {
       options: DocumentPickerOptions<OS>
     ): Promise<DocumentPickerResponse[]>;
     static isCancel<IError extends { code?: string }>(err?: IError): boolean;
-    static releaseSecureAccess(uris: Array<string>): void;    
+    static releaseSecureAccess(uris: Array<string>): void;
     static pickDirectory(): Promise<DirectoryPickerResponse> | null;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,8 +80,8 @@ declare module 'react-native-document-picker' {
   }
   interface DirectoryPickerResponse {
     uri: string;
-    path: string | null;
   }
+  
   type Platform = 'ios' | 'android' | 'windows';
   export default class DocumentPicker<OS extends keyof PlatformTypes = Platform> {
     static types: PlatformTypes['ios'] | PlatformTypes['android'] | PlatformTypes['windows'];

--- a/index.js
+++ b/index.js
@@ -186,6 +186,10 @@ export default class DocumentPicker {
     return err && err.code === E_DOCUMENT_PICKER_CANCELED;
   }
 
+  static releaseSecureAccess(uris) {
+    releaseSecureAccess(uris);    
+  }
+
   static pickDirectory() {
     if (Platform.OS === 'android') {
       return RNDocumentPicker.pickDirectory();

--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ export default class DocumentPicker {
     if (Platform.OS === 'android') {
       return RNDocumentPicker.pickDirectory();
     } else {
-      return null;
+      return Promise.resolve(null);
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ export default class DocumentPicker {
   }
 
   static releaseSecureAccess(uris) {
-    releaseSecureAccess(uris);    
+    releaseSecureAccess(uris);
   }
 
   static pickDirectory() {

--- a/index.js
+++ b/index.js
@@ -186,7 +186,11 @@ export default class DocumentPicker {
     return err && err.code === E_DOCUMENT_PICKER_CANCELED;
   }
 
-  static releaseSecureAccess(uris) {
-    releaseSecureAccess(uris);
+  static pickDirectory() {
+    if (Platform.OS === 'android') {
+      return RNDocumentPicker.pickDirectory();
+    } else {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/rnmods/react-native-document-picker/issues/302

Adds a method to show system directory picker on Android.  Returns the URI of the directory and if possible resolves the URI to the actual path.

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
