### PR TITLE
Added pickDirectory implementation for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See [this](./install-old.md)
 
 ## API
 
-#### [Android only] `DocumentPicker.pickDirectory()`
+#### [Android and Windows only] `DocumentPicker.pickDirectory()`
 
 Open a system directory picker. Returns a promise that resolves to (`{ uri: string }`) of the directory selected by user.
 
@@ -66,7 +66,7 @@ If specified, the picked file is copied to `NSCachesDirectory` / `NSDocumentDire
 
 This should help if you need to work with the file(s) later on, because by default, [the picked documents are temporary files. They remain available only until your application terminates](https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/2902364-documentpicker). This may impact performance for large files, so keep this in mind if you expect users to pick particularly large files and your app does not need immediate read access.
 
-##### [UWP only] `readContent`:`boolean`
+##### [Windows only] `readContent`:`boolean`
 
 Defaults to `false`. If `readContent` is set to true the content of the picked file/files will be read and supplied in the result object.
 
@@ -107,7 +107,7 @@ The display name of the file. _This is normally the filename of the file, but An
 
 The file size of the document. _On Android some DocumentProviders may not provide this information for a document._
 
-##### [UWP only] `content`:
+##### [Windows only] `content`:
 
 The base64 encoded content of the picked file if the option `readContent` was set to `true`.
 

--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ export default class DocumentPicker {
   }
 
   static pickDirectory() {
-    if (Platform.OS === 'android') {
+    if (Platform.OS === 'android' || Platform.OS === 'windows') {
       return RNDocumentPicker.pickDirectory();
     } else {
       return Promise.resolve(null);

--- a/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
+++ b/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
@@ -105,19 +105,27 @@ namespace RNDocumentPicker
         [ReactMethod("pickDirectory")]
         public async Task<JSValueObject> PickDirectory()
         {
-            var openFolderPicker = new FolderPicker();
+            TaskCompletionSource<JSValueObject> tcs = new TaskCompletionSource<JSValueObject>();
 
-            openFolderPicker.ViewMode = PickerViewMode.List;
-            openFolderPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
-            openFolderPicker.FileTypeFilter.Add("*");
-
-            var result = await openFolderPicker.PickSingleFolderAsync();
-            JSValueObject obj = new JSValueObject
+            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
             {
-                { "uri", result.Path }
-            };
+                var openFolderPicker = new FolderPicker();
 
-            return obj;
+                openFolderPicker.ViewMode = PickerViewMode.List;
+                openFolderPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+                openFolderPicker.FileTypeFilter.Add("*");
+
+                var folder = await openFolderPicker.PickSingleFolderAsync();
+                JSValueObject obj = new JSValueObject
+                {
+                    { "uri", folder.Path }
+                };
+
+                tcs.SetResult(obj);
+            });
+
+            var result = await tcs.Task;
+            return result;
         }
 
         private async Task<JSValueObject> PrepareFile(StorageFile file, bool cache, bool readContent)

--- a/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
+++ b/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
@@ -102,6 +102,24 @@ namespace RNDocumentPicker
             return result;
         }
 
+        [ReactMethod("pickDirectory")]
+        public async Task<JSValueObject> PickDirectory()
+        {
+            var openFolderPicker = new FolderPicker();
+
+            openFolderPicker.ViewMode = PickerViewMode.List;
+            openFolderPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+            openFolderPicker.FileTypeFilter.Add("*");
+
+            var result = await openFolderPicker.PickSingleFolderAsync();
+            JSValueObject obj = new JSValueObject
+            {
+                { "uri", result.Path }
+            };
+
+            return obj;
+        }
+
         private async Task<JSValueObject> PrepareFile(StorageFile file, bool cache, bool readContent)
         {
             string base64Content = null;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

This PR provides the `pickDirectory()` feature implementation for Windows. After selecting a folder from your Windows device, the function will return the full path of the folder.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

1. I've installed the module from my branch on a RNW project
2. I've added the following function in the App.js file and I've connected it to the `onPress` event of a `Button `control:

```
const pickFolder = async () => {
  var res = await DocumentPicker.pickDirectory();
  console.log(res.uri);
}
```
3. I've observed the folder picker UI appearing. I've selected a folder.
4. In the debugger log, I've observed the full path of the selected folder being displayed. 

### What's required for testing (prerequisites)?

No special prerequisites, other than a React Native application with Windows support.

### What are the steps to reproduce (after prerequisites)?

1. Add the following function in your code:

```
const pickFolder = async () => {
  var res = await DocumentPicker.pickDirectory();
  console.log(res.uri);
}
```
2. Add a `Button` control in the page which invokes this function when it's pressed.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Windows |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
