### PR TITLE
Added pickDirectory() implementation for Windows (proper PR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you are using RN >= 0.63, only run `pod install` from the ios directory. Then
 
 Use `pickMultiple`, `pickSingle` or `pick` to open a document picker for the user to select file(s). All methods return a Promise.
 
-#### [Android only] `DocumentPicker.pickDirectory()`
+#### [Android and Windows only] `DocumentPicker.pickDirectory()`
 
 Open a system directory picker. Returns a promise that resolves to (`{ uri: string }`) of the directory selected by user.
 
@@ -77,7 +77,7 @@ If specified, the picked file is copied to `NSCachesDirectory` / `NSDocumentDire
 
 This should help if you need to work with the file(s) later on, because by default, [the picked documents are temporary files. They remain available only until your application terminates](https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/2902364-documentpicker). This may impact performance for large files, so keep this in mind if you expect users to pick particularly large files and your app does not need immediate read access.
 
-##### [UWP only] `readContent`:`boolean`
+##### [Windows only] `readContent`:`boolean`
 
 Defaults to `false`. If `readContent` is set to true the content of the picked file/files will be read and supplied in the result object.
 
@@ -118,7 +118,7 @@ The display name of the file. _This is normally the filename of the file, but An
 
 The file size of the document. _On Android some DocumentProviders may not provide this information for a document._
 
-##### [UWP only] `content`:
+##### [Windows only] `content`:
 
 The base64 encoded content of the picked file if the option `readContent` was set to `true`.
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,10 +47,10 @@ type DocumentPickerOptions<OS extends SupportedPlatforms> = {
 }
 
 export function pickDirectory(): Promise<DirectoryPickerResponse | null> {
-  if (Platform.OS === 'android') {
+  if (Platform.OS === 'android' || Platform.OS === 'windows') {
     return RNDocumentPicker.pickDirectory()
   } else {
-    // TODO windows impl
+    // TODO iOS impl
     return Promise.resolve(null)
   }
 }

--- a/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
+++ b/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
@@ -17,7 +17,7 @@ namespace RNDocumentPicker
   {
     private static readonly string OPTION_TYPE = "type";
     private static readonly string CACHE_TYPE = "cache";
-    private static readonly string OPTION_MULIPLE = "allowMultiSelection";
+    private static readonly string OPTION_MULTIPLE = "allowMultiSelection";
     private static readonly string OPTION_READ_CONTENT = "readContent";
     private static readonly string FIELD_URI = "uri";
     private static readonly string FIELD_FILE_COPY_URI = "fileCopyUri";
@@ -45,7 +45,7 @@ namespace RNDocumentPicker
         cache = options.AsObject()[CACHE_TYPE][0].AsBoolean();
       }
 
-      var isMultiple = options.AsObject()[OPTION_MULIPLE].AsBoolean();
+      var isMultiple = options.AsObject()[OPTION_MULTIPLE].AsBoolean();
       bool readContent = false;
       if (options.AsObject().ContainsKey(OPTION_READ_CONTENT))
       {
@@ -133,7 +133,7 @@ namespace RNDocumentPicker
         }
         else
         {
-          tcs.SetResult(null);
+          tcs.SetResult(new JSValueObject());
         }
       });
 

--- a/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
+++ b/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.ReactNative.Managed;
+using Microsoft.ReactNative.Managed;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -12,216 +12,254 @@ using Windows.UI.Core;
 
 namespace RNDocumentPicker
 {
-    [ReactModule("RNDocumentPicker")]
-    internal sealed class RCTDocumentPickerModule
+  [ReactModule("RNDocumentPicker")]
+  internal sealed class RCTDocumentPickerModule
+  {
+    private static readonly string OPTION_TYPE = "type";
+    private static readonly string CACHE_TYPE = "cache";
+    private static readonly string OPTION_MULIPLE = "allowMultiSelection";
+    private static readonly string OPTION_READ_CONTENT = "readContent";
+    private static readonly string FIELD_URI = "uri";
+    private static readonly string FIELD_FILE_COPY_URI = "fileCopyUri";
+    private static readonly string FIELD_NAME = "name";
+    private static readonly string FIELD_TYPE = "type";
+    private static readonly string FIELD_SIZE = "size";
+    private static readonly string FIELD_CONTENT = "content";
+
+
+    [ReactMethod("pick")]
+    public async Task<List<JSValueObject>> Pick(JSValue options)
     {
-        private static readonly string OPTION_TYPE = "type";
-        private static readonly string CACHE_TYPE = "cache";
-        private static readonly string OPTION_MULIPLE = "allowMultiSelection";
-        private static readonly string OPTION_READ_CONTENT = "readContent";
-        private static readonly string FIELD_URI = "uri";
-        private static readonly string FIELD_FILE_COPY_URI = "fileCopyUri";
-        private static readonly string FIELD_NAME = "name";
-        private static readonly string FIELD_TYPE = "type";
-        private static readonly string FIELD_SIZE = "size";
-        private static readonly string FIELD_CONTENT = "content";
+      FileOpenPicker openPicker = new FileOpenPicker();
+      openPicker.ViewMode = PickerViewMode.Thumbnail;
+      openPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
 
+      // Get file type array options
 
-        [ReactMethod("pick")]
-        public async Task<List<JSValueObject>> Pick(JSValue options)
+      var fileTypes = options.AsObject()[OPTION_TYPE].AsArray();
+
+      //var fileTypeArray = options.AsObject()[OPTION_TYPE][0].AsString();
+      bool cache = false;
+      if (options.AsObject().ContainsKey(CACHE_TYPE))
+      {
+        cache = options.AsObject()[CACHE_TYPE][0].AsBoolean();
+      }
+
+      var isMultiple = options.AsObject()[OPTION_MULIPLE].AsBoolean();
+      bool readContent = false;
+      if (options.AsObject().ContainsKey(OPTION_READ_CONTENT))
+      {
+        readContent = options.AsObject()[OPTION_READ_CONTENT].AsBoolean();
+      }
+
+      //if pick called to launch folder picker.
+      bool isFolderPicker = false;
+
+      // Init file type filter
+      if (fileTypes != null)
+      {
+        if (fileTypes.Contains("folder"))
         {
-            FileOpenPicker openPicker = new FileOpenPicker();
-            openPicker.ViewMode = PickerViewMode.Thumbnail;
-            openPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
-
-            // Get file type array options
-
-            var fileTypeArray = options.AsObject()[OPTION_TYPE][0].AsString();
-            bool cache = false;
-            if (options.AsObject().ContainsKey(CACHE_TYPE))
-            {
-                cache = options.AsObject()[CACHE_TYPE][0].AsBoolean();
-            }
-
-            var isMultiple = options.AsObject()[OPTION_MULIPLE].AsBoolean();
-            bool readContent = false;
-            if (options.AsObject().ContainsKey(OPTION_READ_CONTENT))
-            {
-                readContent = options.AsObject()[OPTION_READ_CONTENT].AsBoolean();
-            }
-
-            //if pick called to launch folder picker.
-            bool isFolderPicker = false;
-
-            // Init file type filter
-            if (fileTypeArray != null)
-            {
-                if (fileTypeArray.Contains("folder"))
-                {
-                    isFolderPicker = true;
-                }
-
-                List<string> types = fileTypeArray.Split(' ').ToList();
-                foreach (string type in types)
-                {
-                    if (Regex.Match(type, "(^[.]+[A-Za-z0-9]*$)|(^[*]$)").Success)
-                    {
-                        openPicker.FileTypeFilter.Add(type);
-                    }
-                }
-            }
-            else
-            {
-                openPicker.FileTypeFilter.Add("*");
-            }
-
-            List<JSValueObject> result;
-            if (isFolderPicker)
-            {
-                var openFolderPicker = new FolderPicker();
-
-                openFolderPicker.ViewMode = PickerViewMode.List;
-                openFolderPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
-                openFolderPicker.FileTypeFilter.Add("*");
-
-                result = await PickFolderAsync(openFolderPicker, cache, readContent);
-
-            }
-            else
-            {
-                if (isMultiple)
-                {
-                    result = await PickMultipleFileAsync(openPicker, cache, readContent);
-                }
-                else
-                {
-                    result = await PickSingleFileAsync(openPicker, cache, readContent);
-                }
-            }
-
-            return result;
+          isFolderPicker = true;
         }
 
-        private async Task<JSValueObject> PrepareFile(StorageFile file, bool cache, bool readContent)
+        foreach (var type in fileTypes)
         {
-            string base64Content = null;
-            if (readContent)
+          var item = type.AsString();
+          var list = item.Split(" ");
+          foreach (var extension in list)
+          {
+            if (Regex.Match(extension, "(^[.]+[A-Za-z0-9]*$)|(^[*]$)").Success)
             {
-                var fileStream = await file.OpenReadAsync();
-                using (StreamReader reader = new StreamReader(fileStream.AsStream()))
-                {
-                    using (var memstream = new MemoryStream())
-                    {
-                        await reader.BaseStream.CopyToAsync(memstream);
-                        var bytes = memstream.ToArray();
-                        base64Content = Convert.ToBase64String(bytes);
-                    }
-                }
+              openPicker.FileTypeFilter.Add(extension);
             }
-
-            if (cache == true)
-            {
-                var fileInCache = await file.CopyAsync(ApplicationData.Current.TemporaryFolder, file.Name.ToString(), NameCollisionOption.ReplaceExisting);
-                var basicProperties = await fileInCache.GetBasicPropertiesAsync();
-
-                JSValueObject result = new JSValueObject
-                {
-                    { FIELD_URI, file.Path },
-                    { FIELD_FILE_COPY_URI, file.Path },
-                    { FIELD_TYPE, file.ContentType },
-                    { FIELD_NAME, file.Name },
-                    { FIELD_SIZE, basicProperties.Size},
-                    { FIELD_CONTENT, base64Content }
-                };
-
-                return result;
-            }
-            else
-            {
-                var basicProperties = await file.GetBasicPropertiesAsync();
-
-                JSValueObject result = new JSValueObject
-                {
-                    { FIELD_URI, file.Path },
-                    { FIELD_FILE_COPY_URI, file.Path },
-                    { FIELD_TYPE, file.ContentType },
-                    { FIELD_NAME, file.Name },
-                    { FIELD_SIZE, basicProperties.Size},
-                    { FIELD_CONTENT, base64Content }
-                };
-
-                return result;
-            }
+          }
         }
+      }
+      else
+      {
+        openPicker.FileTypeFilter.Add("*");
+      }
 
-        private async Task<List<JSValueObject>> PickMultipleFileAsync(FileOpenPicker picker, bool cache, bool readContent)
+      List<JSValueObject> result;
+      if (isFolderPicker)
+      {
+        var openFolderPicker = new FolderPicker();
+
+        openFolderPicker.ViewMode = PickerViewMode.List;
+        openFolderPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+        openFolderPicker.FileTypeFilter.Add("*");
+
+        result = await PickFolderAsync(openFolderPicker, cache, readContent);
+
+      }
+      else
+      {
+        if (isMultiple)
         {
-            TaskCompletionSource<List<JSValueObject>> tcs = new TaskCompletionSource<List<JSValueObject>>();
-
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
-            {
-                IReadOnlyList<StorageFile> files = await picker.PickMultipleFilesAsync();
-                if (files.Count > 0)
-                {
-                    List<JSValueObject> jarrayObj = new List<JSValueObject>();
-                    foreach (var file in files)
-                    {
-                        var processedFile = await PrepareFile(file, cache, readContent);
-                        jarrayObj.Add(processedFile);
-                    }
-
-                    tcs.SetResult(jarrayObj);
-                }
-            });
-
-            var result = await tcs.Task;
-            return result;
+          result = await PickMultipleFileAsync(openPicker, cache, readContent);
         }
-
-        private async Task<List<JSValueObject>> PickSingleFileAsync(FileOpenPicker picker, bool cache, bool readContent)
+        else
         {
-            TaskCompletionSource<JSValueObject> tcs = new TaskCompletionSource<JSValueObject>();
-
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
-            {
-                var file = await picker.PickSingleFileAsync();
-                if (file != null)
-                {
-                    var processedFile = await PrepareFile(file, cache, readContent);
-                    tcs.SetResult(processedFile);
-                }
-            });
-
-            var result = await tcs.Task;
-
-            List<JSValueObject> list = new List<JSValueObject>() { result };
-
-            return list;
+          result = await PickSingleFileAsync(openPicker, cache, readContent);
         }
+      }
 
-        private async Task<List<JSValueObject>> PickFolderAsync(FolderPicker picker, bool cache, bool readContent)
-        {
-            TaskCompletionSource<List<JSValueObject>> tcs = new TaskCompletionSource<List<JSValueObject>>();
-
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
-            {
-                var folder = await picker.PickSingleFolderAsync();
-                if (folder != null)
-                {
-                    List<JSValueObject> jarrayObj = new List<JSValueObject>();
-                    var files = await folder.GetFilesAsync();
-                    foreach (var file in files)
-                    {
-                        var preparedFile = await PrepareFile(file, cache, readContent);
-                        jarrayObj.Add(preparedFile);
-                    }
-
-                    tcs.SetResult(jarrayObj);
-                }
-            });
-
-            var result = await tcs.Task;
-            return result;
-        }
+      return result;
     }
+
+    [ReactMethod("pickDirectory")]
+    public async Task<JSValueObject> PickDirectory()
+    {
+      TaskCompletionSource<JSValueObject> tcs = new TaskCompletionSource<JSValueObject>();
+
+      await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+      {
+        var openFolderPicker = new FolderPicker();
+
+        openFolderPicker.ViewMode = PickerViewMode.List;
+        openFolderPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+        openFolderPicker.FileTypeFilter.Add("*");
+
+        var folder = await openFolderPicker.PickSingleFolderAsync();
+        if (folder != null)
+        {
+          JSValueObject obj = new JSValueObject
+                {
+                    { "uri", folder.Path }
+                };
+
+          tcs.SetResult(obj);
+        }
+        else
+        {
+          tcs.SetResult(null);
+        }
+      });
+
+      var result = await tcs.Task;
+      return result;
+    }
+    private async Task<JSValueObject> PrepareFile(StorageFile file, bool cache, bool readContent)
+    {
+      string base64Content = null;
+      if (readContent)
+      {
+        var fileStream = await file.OpenReadAsync();
+        using (StreamReader reader = new StreamReader(fileStream.AsStream()))
+        {
+          using (var memstream = new MemoryStream())
+          {
+            await reader.BaseStream.CopyToAsync(memstream);
+            var bytes = memstream.ToArray();
+            base64Content = Convert.ToBase64String(bytes);
+          }
+        }
+      }
+
+      if (cache == true)
+      {
+        var fileInCache = await file.CopyAsync(ApplicationData.Current.TemporaryFolder, file.Name.ToString(), NameCollisionOption.ReplaceExisting);
+        var basicProperties = await fileInCache.GetBasicPropertiesAsync();
+
+        JSValueObject result = new JSValueObject
+                {
+                    { FIELD_URI, file.Path },
+                    { FIELD_FILE_COPY_URI, file.Path },
+                    { FIELD_TYPE, file.ContentType },
+                    { FIELD_NAME, file.Name },
+                    { FIELD_SIZE, basicProperties.Size},
+                    { FIELD_CONTENT, base64Content }
+                };
+
+        return result;
+      }
+      else
+      {
+        var basicProperties = await file.GetBasicPropertiesAsync();
+
+        JSValueObject result = new JSValueObject
+                {
+                    { FIELD_URI, file.Path },
+                    { FIELD_FILE_COPY_URI, file.Path },
+                    { FIELD_TYPE, file.ContentType },
+                    { FIELD_NAME, file.Name },
+                    { FIELD_SIZE, basicProperties.Size},
+                    { FIELD_CONTENT, base64Content }
+                };
+
+        return result;
+      }
+    }
+
+    private async Task<List<JSValueObject>> PickMultipleFileAsync(FileOpenPicker picker, bool cache, bool readContent)
+    {
+      TaskCompletionSource<List<JSValueObject>> tcs = new TaskCompletionSource<List<JSValueObject>>();
+
+      await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+      {
+        IReadOnlyList<StorageFile> files = await picker.PickMultipleFilesAsync();
+        if (files.Count > 0)
+        {
+          List<JSValueObject> jarrayObj = new List<JSValueObject>();
+          foreach (var file in files)
+          {
+            var processedFile = await PrepareFile(file, cache, readContent);
+            jarrayObj.Add(processedFile);
+          }
+
+          tcs.SetResult(jarrayObj);
+        }
+      });
+
+      var result = await tcs.Task;
+      return result;
+    }
+
+    private async Task<List<JSValueObject>> PickSingleFileAsync(FileOpenPicker picker, bool cache, bool readContent)
+    {
+      TaskCompletionSource<JSValueObject> tcs = new TaskCompletionSource<JSValueObject>();
+
+      await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+      {
+        var file = await picker.PickSingleFileAsync();
+        if (file != null)
+        {
+          var processedFile = await PrepareFile(file, cache, readContent);
+          tcs.SetResult(processedFile);
+        }
+      });
+
+      var result = await tcs.Task;
+
+      List<JSValueObject> list = new List<JSValueObject>() { result };
+
+      return list;
+    }
+
+    private async Task<List<JSValueObject>> PickFolderAsync(FolderPicker picker, bool cache, bool readContent)
+    {
+      TaskCompletionSource<List<JSValueObject>> tcs = new TaskCompletionSource<List<JSValueObject>>();
+
+      await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+      {
+        var folder = await picker.PickSingleFolderAsync();
+        if (folder != null)
+        {
+          List<JSValueObject> jarrayObj = new List<JSValueObject>();
+          var files = await folder.GetFilesAsync();
+          foreach (var file in files)
+          {
+            var preparedFile = await PrepareFile(file, cache, readContent);
+            jarrayObj.Add(preparedFile);
+          }
+
+          tcs.SetResult(jarrayObj);
+        }
+      });
+
+      var result = await tcs.Task;
+      return result;
+    }
+  }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR adds Windows support for the pickDirectory() function.

## Test Plan

![image](https://user-images.githubusercontent.com/1230332/127924710-17f77c77-2191-48c9-a7a1-84b0be436dfb.png)

### What's required for testing (prerequisites)?

See the official prerequisites for React Native for Windows [here](https://microsoft.github.io/react-native-windows/docs/rnw-dependencies)

### What are the steps to reproduce (after prerequisites)?

Move to the root of the project and run:

`yarn example windows`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Windows|    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
