### PR TITLE
fix: TS make DocumentPickerResponse a single response

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,14 +3,14 @@ import invariant from 'invariant'
 import type { PlatformTypes, SupportedPlatforms } from './fileTypes'
 import { perPlatformTypes } from './fileTypes'
 
-export type DocumentPickerResponse = Array<{
+export type DocumentPickerResponse = {
   uri: string
   fileCopyUri: string
   copyError?: string
   type: string
   name: string
   size: number
-}>
+}
 
 export const types = perPlatformTypes[Platform.OS]
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

When using `pickSingle` TS incorrectly expects us to array destructure the response, which shouldn't be the case for a single response. 

Since everywhere in the codebase `DocumentPickerResponse[]` is used where it is expected to be an array, the current `Array<{...}>` notation causes TS to mark this as a nested array, instead of just an array.

In this PR I've removed the `Array<>` notation, making the `pickSingle` having a single response, and the `pickMultiple` still having it's array response.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

`yarn typescript`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
