### PR TITLE
Updated to return empty object or list when user cancels the Open Fil…

### DIFF
--- a/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
+++ b/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
@@ -210,6 +210,10 @@ namespace RNDocumentPicker
 
           tcs.SetResult(jarrayObj);
         }
+        else
++        {
++              tcs.SetResult(new List<JSValueObject>());
++        }
       });
 
       var result = await tcs.Task;
@@ -228,6 +232,10 @@ namespace RNDocumentPicker
           var processedFile = await PrepareFile(file, cache, readContent);
           tcs.SetResult(processedFile);
         }
+        else
++        {
++            tcs.SetResult(new JSValueObject());
++        }
       });
 
       var result = await tcs.Task;


### PR DESCRIPTION
…e dialog - Issue##457

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

It resolves the issue#457 : No exception or error thrown when user cancel File Pick (DocumentPicker.pick) in Windows 

## Test Plan

- Write below function() in Windows React Native project
- Invoke the function
- Cancel the File dialog
- The execution should come to then file name and path should be **undefined** indicating that user cancelled the dialog.
- The implementation is similar to pickDirectory()

function launchFilePicker(): void {
enableModalApp(PickerReturnCodes.File);
DocumentPicker.pick({
type: [DocumentPicker.types.allFiles],
})
.then(result => {
// code
})
.catch(err => {
// code
});
}

### What's required for testing (prerequisites)?
- Windows 10
- react native 0.64.1
- react-native-document-picker 6.0.2

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
