### PR TITLE
Updated to remove additional + characters

### DIFF
--- a/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
+++ b/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
@@ -211,9 +211,9 @@ namespace RNDocumentPicker
           tcs.SetResult(jarrayObj);
         }
         else
-+        {
-+              tcs.SetResult(new List<JSValueObject>());
-+        }
+        {
+           tcs.SetResult(new List<JSValueObject>());
+        }
       });
 
       var result = await tcs.Task;
@@ -233,9 +233,9 @@ namespace RNDocumentPicker
           tcs.SetResult(processedFile);
         }
         else
-+        {
-+            tcs.SetResult(new JSValueObject());
-+        }
+        {
+          tcs.SetResult(new JSValueObject());
+        }
       });
 
       var result = await tcs.Task;


### PR DESCRIPTION
Added additional + characters by the tool in the previous PR : https://github.com/rnmods/react-native-document-picker/pull/462, it would lead to compilation errors, hence created PR to remove additional character.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Windows |    ✅   |
## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
