### PR TITLE
feat: fileCopyUri to be null if copyTo not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ Defaults to `import`. If `mode` is set to `import` the document picker imports t
 
 ##### [iOS and Android only] `copyTo`:`"cachesDirectory" | "documentDirectory"`
 
-If specified, the picked file is copied to `NSCachesDirectory` / `NSDocumentDirectory` (iOS) or `getCacheDir` / `getFilesDir` (Android). The uri of the copy will be available in result's `fileCopyUri`. If copying the file fails (eg. due to lack of space), `fileCopyUri` will be the same as `uri`, and more details about the error will be available in `copyError` field in the result.
+If specified, the picked file is copied to `NSCachesDirectory` / `NSDocumentDirectory` (iOS) or `getCacheDir` / `getFilesDir` (Android). The uri of the copy will be available in result's `fileCopyUri`. If copying the file fails (eg. due to lack of free space), `fileCopyUri` will be `null`, and more details about the error will be available in `copyError` field in the result.
 
 This should help if you need to work with the file(s) later on, because by default, [the picked documents are temporary files. They remain available only until your application terminates](https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/2902364-documentpicker). This may impact performance for large files, so keep this in mind if you expect users to pick particularly large files and your app does not need immediate read access.
+
+On Android, this can be used to obtain local, on-device copy of the file (eg. if user picks a document from google drive, this will download it locally to the phone).
 
 ##### [Windows only] `readContent`:`boolean`
 
@@ -143,7 +145,7 @@ The URI representing the document picked by the user. _On iOS this will be a `fi
 
 ##### `fileCopyUri`
 
-Same as `uri`, but has special meaning if `copyTo` option is specified.
+If `copyTo` option is specified, this will point to a local copy of picked file. Otherwise, this is `null`.
 
 ##### `type`
 

--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
@@ -300,15 +300,15 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
             fileName = String.valueOf(System.currentTimeMillis());
           }
           File destFile = new File(dir, fileName);
-          String path = copyFile(context, uri, destFile);
-          map.putString(FIELD_FILE_COPY_URI, path);
+          String copyPath = copyFile(context, uri, destFile);
+          map.putString(FIELD_FILE_COPY_URI, copyPath);
         } catch (Exception e) {
           e.printStackTrace();
-          map.putString(FIELD_FILE_COPY_URI, uri.toString());
-          map.putString(FIELD_COPY_ERROR, e.getMessage());
+          map.putNull(FIELD_FILE_COPY_URI);
+          map.putString(FIELD_COPY_ERROR, e.getLocalizedMessage());
         }
       } else {
-        map.putString(FIELD_FILE_COPY_URI, uri.toString());
+        map.putNull(FIELD_FILE_COPY_URI);
       }
     }
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -37,6 +37,7 @@ export default function App() {
           try {
             const pickerResult = await DocumentPicker.pickSingle({
               presentationStyle: 'fullScreen',
+              copyTo: 'cachesDirectory',
             })
             setResult([pickerResult])
           } catch (e) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,11 +5,11 @@ import { perPlatformTypes } from './fileTypes'
 
 export type DocumentPickerResponse = {
   uri: string
-  fileCopyUri: string
-  copyError?: string
-  type: string
   name: string
-  size: number
+  copyError?: string
+  fileCopyUri: string | null
+  type: string | null
+  size: number | null
 }
 
 export const types = perPlatformTypes[Platform.OS]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

motivation: `fileCopyUri` is now same as `uri` if no `copyTo` option was provided. This PR makes is so that `fileCopyUri` is specified only if `copyTo` is passed, otherwise is null. This makes the api a little cleaner.

Also made some other minor improvements to code.


## Test Plan

tested on ios emulator and android device using the example app

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
