### PR TITLE
fix: pick up correct android build tools version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('DocumentPicker_compileSdkVersion', 29)
-    buildToolsVersion safeExtGet('DocumentPicker_buildToolsVersion', '29.0.2')
+    compileSdkVersion safeExtGet('compileSdkVersion', 29)
+    buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')
     defaultConfig {
-        minSdkVersion safeExtGet('DocumentPicker_minSdkVersion', 21)
-        targetSdkVersion safeExtGet('DocumentPicker_targetSdkVersion', 29)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
+        targetSdkVersion safeExtGet('targetSdkVersion', 29)
         versionCode 1
         versionName "1.0"
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prepare": "bob build",
-    "release": "release-it",
+    "release": "yarn prepare && release-it",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
     "bootstrap": "yarn example && yarn && yarn pods"

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
     "react-native": "*",
     "react-native-windows": "*"
   },
+  "peerDependenciesMeta": {
+    "react-native-windows": {
+      "optional": true
+    }
+  },
   "jest": {
     "preset": "react-native",
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

closes #446, flags RNwindows as optional

## Test Plan

android: tested in example project and seeing that this influences the "external libraries" in android studio, the settings does have effect


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
