### PR TITLE
replaced jCenter with mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
 
         dependencies {
@@ -49,7 +49,6 @@ repositories {
         url("$rootDir/../node_modules/react-native/android")
     }
     google()
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
# Summary

jCenter will be offline in February 2022. I've updated the android project to use maven.

## Test Plan
I've tested the library on a personal project and it builds without issues.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅.    |

## Checklist

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)