### PR TITLE
Fix: `fileCopyUri` should include the URI schema

### DIFF
--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
@@ -326,7 +326,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
           }
           out.close();
           in.close();
-          return destFile.getAbsolutePath();
+          return destFile.toURI().toString();
         } else {
           throw new NullPointerException("Invalid input stream");
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Make the `fileCopyUri` be a URI string and include the schema prefix (usually `file:/`)

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
- fixes #526

A URI should begin with the schema prefix
In iOS `fileCopyUri` already works that way
Missing the schema prefix causes a problem when you try to use `fileCopyUri` with `fetch` to upload a file

### Why `.toURI().toString()` 

This was the only method I've found that returned the schema as part of the string
The same thing is used in [RN image picker here](https://github.com/react-native-image-picker/react-native-image-picker/blob/feafc8810420e08af41fe898d9a2372e835185e0/android/src/main/java/com/imagepicker/Utils.java#L397)

### Difference between `file:/` and `file:///` 

Since on `iOS` `fileCopyUri` is returned with a `file:///` prefix - you might be wondering if this is a problem.
According to wikipedia `file:/` and `file:///` are the same thing: https://en.wikipedia.org/wiki/File_URI_scheme#How_many_slashes.3F

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I've manually tested the changes in the example app and in an external app

#### Before (no `file:/` prefix for `fileCopyUri`)
![RN_Document_Picker_Before](https://user-images.githubusercontent.com/12156624/150009645-c0c502d2-e5b8-4c5b-b701-4e0ab542d54c.png)

```json
 LOG  [
  {
    "size": 3028,
    "fileCopyUri": "/data/user/0/com.example.reactnativedocumentpicker/cache/7246f3d1-815b-45fa-86ce-a420da059da4/sample.pdf",
    "name": "sample.pdf",
    "type": "application/pdf",
    "uri": "content://com.android.providers.downloads.documents/document/18"
  }
]
```

#### After 
![RN_Document_Picker_After](https://user-images.githubusercontent.com/12156624/150009817-42e1508a-0d29-4295-9e68-8dcc2c6e3b65.png)

```json
 LOG  [
  {
    "size": 3028,
    "fileCopyUri": "file:/data/user/0/com.example.reactnativedocumentpicker/cache/d87a83fe-e393-40f2-9f5f-f3ebe2641974/sample.pdf",
    "name": "sample.pdf",
    "type": "application/pdf",
    "uri": "content://com.android.providers.downloads.documents/document/18"
  }
]
```

#### Sample video (after) in our app:

https://user-images.githubusercontent.com/12156624/150010016-9e50f735-e0ae-40d6-8327-db95981e1f29.mp4
- You can see that we used to test whether `fileCopyUri` starts with a scheme and added `file:` if it didn't 
- Now that's no longer necessary

#### Sample for the same in iOS
No iOS change, but just showing how it already works there: 
![RN_Document_Picker_iOS](https://user-images.githubusercontent.com/12156624/150010488-587efb1a-e62e-4c06-811d-6e98cb6f0bd4.png)

### What's required for testing (prerequisites)?

This can be manually tested in the example app

### What are the steps to reproduce (after prerequisites)?

1. Use the example app on Android
2. Use the "Open Picker For Single File Selection" button 
    (Or any button that passes a `copyTo` Document Picker Option)
2. Select a file
3. See the displayed `fileCopyUri` - it should contain the URI schema in the beginning e.g. `file:/` 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- n/a I added the documentation in `README.md`
- n/a I updated the typed files (TS and Flow)
