### PR TITLE
fix(ios): decode URI for iOS

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -134,7 +134,18 @@ function doPick<OS extends SupportedPlatforms>(
     throw new TypeError('Invalid copyTo option: ' + options.copyTo)
   }
 
-  return RNDocumentPicker.pick(options)
+  return RNDocumentPicker.pick(options).then((pickerDocuments) => {
+    if (Platform.OS === 'ios') {
+      return pickerDocuments.map((pickerDocument) => ({
+        ...pickerDocument,
+        fileCopyUri: pickerDocument.fileCopyUri
+          ? decodeURIComponent(pickerDocument.fileCopyUri)
+          : null,
+        uri: decodeURIComponent(pickerDocument.uri),
+      }))
+    }
+    return pickerDocuments
+  })
 }
 
 export function releaseSecureAccess(uris: Array<string>): Promise<void> {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -136,13 +136,12 @@ function doPick<OS extends SupportedPlatforms>(
 
   return RNDocumentPicker.pick(options).then((pickerDocuments) => {
     if (Platform.OS === 'ios') {
-      return pickerDocuments.map((pickerDocument) => ({
-        ...pickerDocument,
-        fileCopyUri: pickerDocument.fileCopyUri
-          ? decodeURIComponent(pickerDocument.fileCopyUri)
-          : null,
-        uri: decodeURIComponent(pickerDocument.uri),
-      }))
+      pickerDocuments.forEach((document) => {
+        document.uri = decodeURIComponent(document.uri)
+        if (document.fileCopyUri) {
+          document.fileCopyUri = decodeURIComponent(document.fileCopyUri)
+        }
+      })
     }
     return pickerDocuments
   })


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

There is a common issue related to space the file names in iOS. But, this may not be apparent when debugging.  

In order to resolve it, you need to decode the URI. 

@vonovak has also suggested the same solution in https://github.com/rnmods/react-native-document-picker/issues/199#issuecomment-932807046

There are other issues that mention it: https://github.com/rnmods/react-native-document-picker/issues/350, https://github.com/rnmods/react-native-document-picker/issues/291, and https://github.com/rnmods/react-native-document-picker/issues/13


### What's required for testing (prerequisites)?

- Upload file names with spaces in iOS
- Check if they can be loaded using the `uri`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
