### PR TITLE
feat: support transitionStyle on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Requires RN >= 0.63, Android 5.0+ and iOS 11+
       - [allowMultiSelection:boolean](#allowmultiselectionboolean)
       - [type:string|Array&lt;string&gt;](#typestringarraystring)
       - [[iOS only] presentationStyle:'fullScreen' | 'pageSheet' | 'formSheet' | 'overFullScreen'](#ios-only-presentationstylefullscreen--pagesheet--formsheet--overfullscreen)
+      - [[iOS only] transitionStyle:'coverVertical' | 'flipHorizontal' | 'crossDissolve' | 'partialCurl'](#ios-only-transitionstylecoververtical--fliphorizontal--crossdissolve--partialcurl)
       - [[iOS only] mode:"import" | "open"](#ios-only-modeimport--open)
       - [[iOS and Android only] copyTo:"cachesDirectory" | "documentDirectory"](#ios-and-android-only-copytocachesdirectory--documentdirectory)
       - [[Windows only] readContent:boolean](#windows-only-readcontentboolean)
@@ -105,6 +106,10 @@ The type or types of documents to allow selection of. May be an array of types a
 ##### [iOS only] `presentationStyle`:`'fullScreen' | 'pageSheet' | 'formSheet' | 'overFullScreen'`
 
 Controls how the picker is presented, eg. on an iPad you may want to present it fullscreen. Defaults to `pageSheet`.
+
+##### [iOS only] `transitionStyle`:`'coverVertical' | 'flipHorizontal' | 'crossDissolve' | 'partialCurl'`
+
+Configure the transition style of the picker. Defaults to `coverVertical`, when the picker is presented, its view slides up from the bottom of the screen.
 
 ##### [iOS only] `mode`:`"import" | "open"`
 

--- a/ios/RNDocumentPicker.m
+++ b/ios/RNDocumentPicker.m
@@ -37,6 +37,19 @@ RCT_ENUM_CONVERTER(
     integerValue)
 @end
 
+@implementation RCTConvert (ModalTransitionStyle)
+
+RCT_ENUM_CONVERTER(
+    UIModalTransitionStyle,
+    (@{
+      @"coverVertical" : @(UIModalTransitionStyleCoverVertical),
+      @"flipHorizontal" : @(UIModalTransitionStyleFlipHorizontal),
+      @"crossDissolve" : @(UIModalTransitionStyleCrossDissolve),
+      @"partialCurl" : @(UIModalTransitionStylePartialCurl),
+    }),
+    UIModalTransitionStyleCoverVertical,
+    integerValue)
+@end
 
 @interface RNDocumentPicker () <UIDocumentPickerDelegate, UIAdaptivePresentationControllerDelegate>
 @end
@@ -85,12 +98,14 @@ RCT_EXPORT_METHOD(pick:(NSDictionary *)options
     mode = options[@"mode"] && [options[@"mode"] isEqualToString:@"open"] ? UIDocumentPickerModeOpen : UIDocumentPickerModeImport;
     copyDestination = options[@"copyTo"];
     UIModalPresentationStyle presentationStyle = [RCTConvert UIModalPresentationStyle:options[@"presentationStyle"]];
+    UIModalTransitionStyle transitionStyle = [RCTConvert UIModalTransitionStyle:options[@"transitionStyle"]];
     [promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject fromCallSite:@"pick"];
 
     NSArray *allowedUTIs = [RCTConvert NSArray:options[OPTION_TYPE]];
     UIDocumentPickerViewController *documentPicker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:allowedUTIs inMode:mode];
 
     documentPicker.modalPresentationStyle = presentationStyle;
+    documentPicker.modalTransitionStyle = transitionStyle;
 
     documentPicker.delegate = self;
     documentPicker.presentationController.delegate = self;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,6 +26,8 @@ type DocumentPickerType = {
 
 const RNDocumentPicker: DocumentPickerType = NativeModules.RNDocumentPicker
 
+type TransitionStyle = 'coverVertical' | 'flipHorizontal' | 'crossDissolve' | 'partialCurl'
+
 export type DocumentPickerOptions<OS extends SupportedPlatforms> = {
   type?:
     | string
@@ -34,10 +36,11 @@ export type DocumentPickerOptions<OS extends SupportedPlatforms> = {
   mode?: 'import' | 'open'
   copyTo?: 'cachesDirectory' | 'documentDirectory'
   allowMultiSelection?: boolean
+  transitionStyle?: TransitionStyle
 } & Pick<ModalPropsIOS, 'presentationStyle'>
 
 export async function pickDirectory<OS extends SupportedPlatforms>(
-  params?: Pick<DocumentPickerOptions<OS>, 'presentationStyle'>,
+  params?: Pick<DocumentPickerOptions<OS>, 'presentationStyle' | 'transitionStyle'>,
 ): Promise<DirectoryPickerResponse | null> {
   if (Platform.OS === 'ios') {
     const result = await pick({
@@ -83,6 +86,7 @@ export function pick<OS extends SupportedPlatforms>(
 
   const newOpts: DoPickParams<OS> = {
     presentationStyle: 'formSheet',
+    transitionStyle: 'coverVertical',
     ...options,
     type: Array.isArray(options.type) ? options.type : [options.type],
   }
@@ -94,6 +98,7 @@ type DoPickParams<OS extends SupportedPlatforms> = DocumentPickerOptions<OS> & {
   type: Array<PlatformTypes[OS][keyof PlatformTypes[OS]] | string>
   allowMultiSelection: boolean
   presentationStyle: NonNullable<ModalPropsIOS['presentationStyle']>
+  transitionStyle: TransitionStyle
 }
 
 function doPick<OS extends SupportedPlatforms>(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ type DocumentPickerType = {
 
 const RNDocumentPicker: DocumentPickerType = NativeModules.RNDocumentPicker
 
-type TransitionStyle = 'coverVertical' | 'flipHorizontal' | 'crossDissolve' | 'partialCurl'
+export type TransitionStyle = 'coverVertical' | 'flipHorizontal' | 'crossDissolve' | 'partialCurl'
 
 export type DocumentPickerOptions<OS extends SupportedPlatforms> = {
   type?:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Added `transitionStyle` option on iOS to configure the transition style of the picker.

**Example, `transitionStyle: 'flipHorizontal'`:**

<img width="320" src="https://user-images.githubusercontent.com/37284154/160306958-c03272e1-3251-401f-a97f-fcca0abc05ec.gif" />

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

tested on ios emulator using the example app, change `transitionStyle` option.

### What are the steps to reproduce (after prerequisites)?

run the example app

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
