### PR TITLE
fix: intent type not set in case of multiple mime types filter

### DIFF
--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
@@ -131,6 +131,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
           if (types.size() > 1) {
             String[] mimeTypes = readableArrayToStringArray(types);
             intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
+            intent.setType(String.join("|",mimeTypes));
           } else if (types.size() == 1) {
             intent.setType(types.getString(0));
           }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

This PR fixes issue #513, where even after restricting file types the user could choose any file type (only in case of multiple types)

This is fixed by calling `setType` on ACTION_GET_CONTENT intent with provided `mimeTypes` separated by `|`
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
The example application is sufficient, provided the emulator/device has some example .doc and .png files

### What are the steps to reproduce (after prerequisites)?
Steps to reproduce the issue - 
* Open the example app (without this commit) on an android device
* Select `Open picker for multi-selection of word files` option
* If there are image files in the gallery, you'll be able to select them

Steps to verify the fix - 
Re-run the app with this commit merged, will only be able to select restricted file types.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
