### PR TITLE
Add vcard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The base64 encoded content of the picked file if the option `readContent` was se
 - `DocumentPicker.types.pptx`: pptx files
 - `DocumentPicker.types.xls`: xls files
 - `DocumentPicker.types.xlsx`: xlsx files
+- `DocumentPicker.types.vcard`: vCard files
 
 #### `DocumentPicker.isCancel(err)`
 

--- a/src/fileTypes.ts
+++ b/src/fileTypes.ts
@@ -13,6 +13,7 @@ const mimeTypes = Object.freeze({
   xls: 'application/vnd.ms-excel',
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   zip: 'application/zip',
+  vcard: 'text/x-vcard',
 } as const)
 
 const utis = Object.freeze({
@@ -30,6 +31,7 @@ const utis = Object.freeze({
   xls: 'com.microsoft.excel.xls',
   xlsx: 'org.openxmlformats.spreadsheetml.sheet',
   zip: 'public.zip-archive',
+  vcard: 'public.vcard',
 } as const)
 
 const extensions = Object.freeze({
@@ -48,6 +50,7 @@ const extensions = Object.freeze({
   xls: '.xls',
   xlsx: '.xlsx',
   zip: '.zip .gz',
+  vcard: '.vcard .vcf',
 } as const)
 
 export type PlatformTypes = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Adds support for picking vCard files, also known as Virtual Contact File (`.vcf`). It is useful for sending contact data.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

- a `.vcf` file - can be exported from iOS Contacts app by Share Contact > Save to Files
### What are the steps to reproduce (after prerequisites)?
- add `types.vcard` type to pick, pickSingle or pickMultiple requests:
```tsx
 DocumentPicker.pickSingle({
     type: types.vcard,
 })
```
- confirm that vcf file can be selected
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
