### PR TITLE
docs: document using decodeURIComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,17 +87,17 @@ If you are using RN >= 0.63, only run `pod install` from the ios directory. Then
 
 ## API
 
-#### `DocumentPicker.pickMultiple(options)` / `DocumentPicker.pickSingle(options)` / `DocumentPicker.pick(options)`
+### `DocumentPicker.pickMultiple(options)` / `DocumentPicker.pickSingle(options)` / `DocumentPicker.pick(options)`
 
 ⚠️ Breaking in v6: `pick` returns a `Promise<Array<DocumentPickerResponse>>` instead of `Promise<DocumentPickerResponse>`. If you were using `pick`, change those usages to `pickSingle`.
 
 Use `pickMultiple`, `pickSingle` or `pick` to open a document picker for the user to select file(s). All methods return a Promise.
 
-#### `DocumentPicker.pickDirectory()`
+### `DocumentPicker.pickDirectory()`
 
 Open a system directory picker. Returns a promise that resolves to (`{ uri: string }`) of the directory selected by user.
 
-#### `DocumentPicker.pick(options)` and `DocumentPicker.pickMultiple(options)`
+### `DocumentPicker.pick(options)` and `DocumentPicker.pickMultiple(options)`
 
 - `pick` is the most universal, you can use `allowMultiSelection` param to control whether or not user can select multiple files (`false` by default). Returns a `Promise<Array<DocumentPickerResponse>>`
 
@@ -106,15 +106,15 @@ Open a system directory picker. Returns a promise that resolves to (`{ uri: stri
 - `pickSingle` only allows a single selection and the Promise will resolve to that single result (same behavior as `pick` in v5)
 - `pickMultiple` allows multiple selection and the Promise will resolve to an array of results.
 
-### Options
+## Options
 
 All of the options are optional
 
-##### `allowMultiSelection`:`boolean`
+#### `allowMultiSelection`:`boolean`
 
-Whether or not selecting multiple files is allowed. For `pick`, this is `false` by default. `allowMultiSelection` is `false` for `pickSingle` and `true` for `pickMultiple` and cannot be overridden for those calls.
+Whether selecting multiple files is allowed. For `pick`, this is `false` by default. `allowMultiSelection` is `false` for `pickSingle` and `true` for `pickMultiple` and cannot be overridden for those calls.
 
-##### `type`:`string|Array<string>`
+#### `type`:`string|Array<string>`
 
 The type or types of documents to allow selection of. May be an array of types as single type string.
 
@@ -122,27 +122,27 @@ The type or types of documents to allow selection of. May be an array of types a
 - On iOS these must be Apple "[Uniform Type Identifiers](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html)"
 - If `type` is omitted it will be treated as `*/*` or `public.item`.
 
-##### [iOS only] `presentationStyle`:`'fullScreen' | 'pageSheet' | 'formSheet' | 'overFullScreen'`
+#### [iOS only] `presentationStyle`:`'fullScreen' | 'pageSheet' | 'formSheet' | 'overFullScreen'`
 
 Controls how the picker is presented, eg. on an iPad you may want to present it fullscreen. Defaults to `pageSheet`.
 
-##### [iOS only] `transitionStyle`:`'coverVertical' | 'flipHorizontal' | 'crossDissolve' | 'partialCurl'`
+#### [iOS only] `transitionStyle`:`'coverVertical' | 'flipHorizontal' | 'crossDissolve' | 'partialCurl'`
 
 Configure the transition style of the picker. Defaults to `coverVertical`, when the picker is presented, its view slides up from the bottom of the screen.
 
-##### [iOS only] `mode`:`"import" | "open"`
+#### [iOS only] `mode`:`"import" | "open"`
 
 Defaults to `import`. If `mode` is set to `import` the document picker imports the file from outside to inside the sandbox, otherwise if `mode` is set to `open` the document picker opens the file right in place.
 
-##### [iOS and Android only] `copyTo`:`"cachesDirectory" | "documentDirectory"`
+#### [iOS and Android only] `copyTo`:`"cachesDirectory" | "documentDirectory"`
 
 If specified, the picked file is copied to `NSCachesDirectory` / `NSDocumentDirectory` (iOS) or `getCacheDir` / `getFilesDir` (Android). The uri of the copy will be available in result's `fileCopyUri`. If copying the file fails (eg. due to lack of free space), `fileCopyUri` will be `null`, and more details about the error will be available in `copyError` field in the result.
 
 This should help if you need to work with the file(s) later on, because by default, [the picked documents are temporary files. They remain available only until your application terminates](https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/2902364-documentpicker). This may impact performance for large files, so keep this in mind if you expect users to pick particularly large files and your app does not need immediate read access.
 
-On Android, this can be used to obtain local, on-device copy of the file (eg. if user picks a document from google drive, this will download it locally to the phone).
+On Android, this can be used to obtain local, on-device copy of the file (e.g. if user picks a document from google drive, this will download it locally to the phone).
 
-##### [Windows only] `readContent`:`boolean`
+#### [Windows only] `readContent`:`boolean`
 
 Defaults to `false`. If `readContent` is set to true the content of the picked file/files will be read and supplied in the result object.
 
@@ -155,39 +155,41 @@ Defaults to `false`. If `readContent` is set to true the content of the picked f
 
   https://docs.microsoft.com/en-us/windows/uwp/files/file-access-permissions
 
-  Unfortunately that permission is not granted to the whole app, but only the Thread which handled the filepicker. Therefore it can be useful to read the file directly.
+  Unfortunately that permission is not granted to the whole app, but only the Thread which handled the filepicker. Therefore, it can be useful to read the file directly.
 
 - You can use `react-native-fs` on Android and IOS to read the picked file.
 
-### Result
+## Result
 
 The `pick` Promise resolves to an array of objects with the following keys.
 
-##### `uri`
+#### `uri`
 
 The URI representing the document picked by the user. _On iOS this will be a `file://` URI for a temporary file in your app's container if `mode` is not specified or set at `import` otherwise it will be the original `file://` URI. On Android this will be a `content://` URI for a document provided by a DocumentProvider that must be accessed with a ContentResolver._
 
-##### `fileCopyUri`
+Please note that you might need to use `decodeURIComponent` in order to get the URI in the format you need for further processing, e.g. when using `react-native-fs`.
+
+#### `fileCopyUri`
 
 If `copyTo` option is specified, this will point to a local copy of picked file. Otherwise, this is `null`.
 
-##### `type`
+#### `type`
 
 The MIME type of the file. _On Android some DocumentProviders may not provide MIME types for their documents. On iOS this MIME type is based on the best MIME type for the file extension according to Apple's internal "Uniform Type Identifiers" database._
 
-##### `name`
+#### `name`
 
 The display name of the file. _This is normally the filename of the file, but Android does not guarantee that this will be a filename from all DocumentProviders._
 
-##### `size`
+#### `size`
 
 The file size of the document. _On Android some DocumentProviders may not provide this information for a document._
 
-##### [Windows only] `content`
+#### [Windows only] `content`
 
 The base64 encoded content of the picked file if the option `readContent` was set to `true`.
 
-### `DocumentPicker.types.*`
+## `DocumentPicker.types.*`
 
 `DocumentPicker.types.*` provides a few common types for use as `type` values, these types will use the correct format for each platform (MIME types on Android, UTIs on iOS).
 
@@ -205,19 +207,19 @@ The base64 encoded content of the picked file if the option `readContent` was se
 - `DocumentPicker.types.xls`: xls files
 - `DocumentPicker.types.xlsx`: xlsx files
 
-#### `DocumentPicker.isCancel(err)`
+### `DocumentPicker.isCancel(err)`
 
 If the user cancels the document picker without choosing a file (by pressing the system back button on Android or the Cancel button on iOS) the Promise will be rejected with a cancellation error. You can check for this error using `DocumentPicker.isCancel(err)` allowing you to ignore it and cleanup any parts of your interface that may not be needed anymore.
 
-#### `DocumentPicker.isInProgress(err)`
+### `DocumentPicker.isInProgress(err)`
 
-If the user somehow manages to open multiple file pickers (eg. due the app being unresponsive), then only the picked result from the last opened picker will be considered and the promises form previous opened pickers will be rejected with an error that you can check using `DocumentPicker.isInProgress()`.
+If the user somehow manages to open multiple file pickers (eg. due the app being unresponsive), then only the picked result from the last opened picker will be considered and the promises from previous opened pickers will be rejected with an error that you can check using `DocumentPicker.isInProgress()`.
 
 This behavior might change in future to allow opening only a single picker at a time. The internal logic is currently implemented only on iOS.
 
-#### [iOS only] `DocumentPicker.releaseSecureAccess(uris: Array<string>)`
+### [iOS only] `DocumentPicker.releaseSecureAccess(uris: Array<string>)`
 
-If `mode` is set to `open` iOS is giving you a secure access to a file located outside from your sandbox.
+If `mode` is set to `open` iOS is giving you secure access to a file located outside from your sandbox.
 In that case Apple is asking you to release the access as soon as you finish using the resource.
 
 ## Example


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

this documents the possible need for using `decodeURIComponent` to decode the obtained uri.

also the readme should be a little easier to read (bigger headings)

closes #544 
