### PR TITLE
fix: close cursor in getMetadata

### DIFF
--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
@@ -261,7 +261,8 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
       WritableMap map = Arguments.createMap();
       map.putString(FIELD_URI, uri.toString());
       map.putString(FIELD_TYPE, contentResolver.getType(uri));
-      try (Cursor cursor = contentResolver.query(uri, null, null, null, null, null)) {
+      Cursor cursor = contentResolver.query(uri, null, null, null, null, null);
+      try {
         if (cursor != null && cursor.moveToFirst()) {
           int displayNameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
           if (!cursor.isNull(displayNameIndex)) {
@@ -276,6 +277,10 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
           if (!cursor.isNull(sizeIndex)) {
             map.putInt(FIELD_SIZE, cursor.getInt(sizeIndex));
           }
+        }
+      } finally {
+        if(cursor != null) {
+          cursor.close();
         }
       }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

`getMetadata` relies on a Cursor that needs to be closed after using it 

## Test Plan

### What's required for testing (prerequisites)?

NA

### What are the steps to reproduce (after prerequisites)?

NA

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
