### PR TITLE
fix(android): support picking 2+ GB files

### DIFF
--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
@@ -275,10 +275,10 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
             map.putString(FIELD_TYPE, cursor.getString(mimeIndex));
           }
           int sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE);
-          if (!cursor.isNull(sizeIndex)) {
-            map.putInt(FIELD_SIZE, cursor.getInt(sizeIndex));
-          } else {
+          if (cursor.isNull(sizeIndex)) {
             map.putNull(FIELD_SIZE);
+          } else {
+            map.putDouble(FIELD_SIZE, cursor.getLong(sizeIndex));
           }
         }
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

closes #599
closes #119 

## Test Plan

tested locally with 3GB file on simulators for both platforms

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
