### PR TITLE
fix(android): DocumentPicker throw error [Error: User canceled docume…

### DIFF
--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
@@ -141,7 +141,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
       boolean multiple = !args.isNull(OPTION_MULTIPLE) && args.getBoolean(OPTION_MULTIPLE);
       intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple);
 
-      currentActivity.startActivityForResult(Intent.createChooser(intent, null), READ_REQUEST_CODE, Bundle.EMPTY);
+      currentActivity.startActivityForResult(intent, READ_REQUEST_CODE, Bundle.EMPTY);
     } catch (ActivityNotFoundException e) {
       sendError(E_UNABLE_TO_OPEN_FILE_TYPE, e.getLocalizedMessage());
     } catch (Exception e) {


### PR DESCRIPTION
…nt picker]

Fix Error: User canceled document picker
Issue with many different devices (Motorola G7, Huawei P30 Pro, Samsung Galaxy Note 9, Huawei P30...). All users with the problem have Android 10.0, but not all users with android 10 have this issue.

refer to: https://github.com/react-native-image-picker/react-native-image-picker/pull/1854

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
## Issue
https://github.com/rnmods/react-native-document-picker/issues/440

## Motivation
fix(android): DocumentPicker throw error [Error: User canceled document picker]

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
react-native run-android
### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
