### PR TITLE
feat(windows): store directory for later access

### DIFF
--- a/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
+++ b/windows/ReactNativeDocumentPicker/RCTDocumentPickerModule.cs
@@ -130,6 +130,9 @@ namespace RNDocumentPicker
                 };
 
           tcs.SetResult(obj);
+          // TODO: Replace with a more principled solution
+          Windows.Storage.AccessCache.StorageApplicationPermissions.
+                            FutureAccessList.AddOrReplace("pickedFolderToken", folder);
         }
         else
         {
@@ -212,7 +215,7 @@ namespace RNDocumentPicker
         }
         else
         {
-           tcs.SetResult(new List<JSValueObject>());
+          tcs.SetResult(new List<JSValueObject>());
         }
       });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
Closes #511. Allows permission to up to 1,000 directories. [Further reading](https://learn.microsoft.com/en-us/windows/uwp/files/file-access-permissions)

FULL DISCLOSURE: I was unable to get the example to run before making any changes, and haven't fully debugged that, but this change has been tested in my other projects.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
No special setup. Simply use Windows.

### What are the steps to reproduce (after prerequisites)?
Open a directory outside of the main app bundle and attempt to do file operations with it.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Windows|    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device
