### PR TITLE
Add image geolocation to the result

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Requires RN >= 0.63, Android 5.0+ and iOS 11+
       - [type](#type)
       - [name](#name)
       - [size](#size)
+      - [latitude](#latitude)
+      - [longitude](#longitude)
       - [[Windows only] content](#windows-only-content)
     - [DocumentPicker.types.\*](#documentpickertypes)
       - [DocumentPicker.isCancel(err)](#documentpickeriscancelerr)
@@ -184,6 +186,14 @@ The display name of the file. _This is normally the filename of the file, but An
 #### `size`
 
 The file size of the document. _On Android some DocumentProviders may not provide this information for a document._
+
+#### `latitude`
+
+Get geolocation latitude metadata of the image if avaliable, return `null` if not exist.
+
+#### `longitude`
+
+Get geolocation longitude metadata of the image if avaliable, return `null` if not exist.
 
 #### [Windows only] `content`
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
     compileSdkVersion safeExtGet('compileSdkVersion', 29)
     buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 24)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 29)
         versionCode 1
         versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
     compileSdkVersion safeExtGet('compileSdkVersion', 29)
     buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 21)
+        minSdkVersion safeExtGet('minSdkVersion', 24)
         targetSdkVersion safeExtGet('targetSdkVersion', 29)
         versionCode 1
         versionName "1.0"
@@ -53,4 +53,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "androidx.exifinterface:exifinterface:1.3.6"
 }

--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPickerModule.java
@@ -14,6 +14,7 @@ import android.provider.OpenableColumns;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.exifinterface.media.ExifInterface;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
@@ -281,6 +282,25 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
             map.putDouble(FIELD_SIZE, cursor.getLong(sizeIndex));
           }
         }
+      }
+
+      try {
+        InputStream inputStream = contentResolver.openInputStream(uri);
+        ExifInterface exif = new ExifInterface(inputStream);
+
+        double[] latLong = exif.getLatLong();
+        if (latLong != null) {
+          map.putDouble("latitude", latLong[0]);
+          map.putDouble("longitude", latLong[1]);
+        } else {
+          map.putNull("latitude");
+          map.putNull("longitude");
+        }
+        inputStream.close();
+      }
+      catch (Exception e){
+        map.putNull("latitude");
+        map.putNull("longitude");
       }
 
       prepareFileUri(context, map, uri);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,8 @@ export type DocumentPickerResponse = {
   fileCopyUri: string | null
   type: string | null
   size: number | null
+  latitude: string | null
+  longitude: string | null
 }
 
 export const types = perPlatformTypes[Platform.OS]


### PR DESCRIPTION
# Summary

Add image geolocation to the result, The reason why I did this because I needed some extra data from images.

### What are the steps to reproduce (after prerequisites)?

```js
const res = await DocumentPicker.pickSingle({
        type: [DocumentPicker.types.images, DocumentPicker.types.pdf],
        copyTo: 'documentDirectory'
      })
      console.log(res)
```
getting this result:

```
{"fileCopyUri": "file:///data/user/0/br.com.cloq/files/a3914010-2d38-4ef9-866b-dd626bc31614/IMG_20230430_213703.jpg", "latitude": 26.335099999999997, "longitude": 17.228327777777775, "name": "IMG_20230430_213703.jpg", "size": 121504, "type": "image/jpeg", "uri": "content://com.android.providers.media.documents/document/image%3A1000000021"}
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
