### PR TITLE
fix: ignore foreign onActivityResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ New architecture is supported.
 
 - [react-native-document-picker](#react-native-document-picker)
   - [Installation](#installation)
-  - [RN &gt;= 0.69](#rn--063)
+  - [RN &gt;= 0.69](#rn--069)
   - [API](#api)
     - [pickSingle(options) / pick(options)](#picksingleoptions--pickoptions)
     - [pickDirectory()](#pickdirectory)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

`onActivityResult` might be called when some other module calls startActivityForResult and we need to ignore those calls. Right now there was a warning logged, which was a false alarm.

## Test Plan

tested locally

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
