### PR TITLE
fix: .CSV files cannot be selected on Android using the type csv

### DIFF
--- a/src/fileTypes.ts
+++ b/src/fileTypes.ts
@@ -1,7 +1,7 @@
 const mimeTypes = Object.freeze({
   allFiles: '*/*',
   audio: 'audio/*',
-  csv: 'text/csv',
+  csv: 'text/comma-separated-values',
   doc: 'application/msword',
   docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   images: 'image/*',


### PR DESCRIPTION
Resolve the issue on Android where .csv files cannot be selected
On /src/fileTypes.ts on line 4 the current version on master says:
`csv: 'text/csv',`

and I replace for:

`csv: 'text/comma-separated-values',`

With this change is possible to read csv files on Android as it should be expected. This works because when reading a .csv file using allFiles then accessing to the "type" property it returns "text/comma-separated-values".

For testing I provide this screenshots

Before the fix

<img width="1440" alt="image" src="https://github.com/rnmods/react-native-document-picker/assets/32473673/8251f9d4-d810-4ce2-b219-9866bb9bc744">

Here I show the screen where the user is suppose to select a csv file

<img width="1440" alt="image" src="https://github.com/rnmods/react-native-document-picker/assets/32473673/93e15dce-dc04-4eeb-b6bf-21180b4658dd">

Here the user sees the file explorer, in this case the Downloads folder where I have a csv file, the csv file is display on the right window of vscode for reference of the content. We can see is a valid csv file but the code on the center window using 

`const res: DocumentPickerResponse = await DocumentPicker.pickSingle({
            type: [DocumentPicker.types.csv],
            });`

Does not allows use to pick the csv file

After the fix

<img width="1440" alt="image" src="https://github.com/rnmods/react-native-document-picker/assets/32473673/8a774ac0-e048-4899-872c-e3c44ea62ded">

With the fix the csv file is allowed to be picked

<img width="1440" alt="image" src="https://github.com/rnmods/react-native-document-picker/assets/32473673/169def64-2a13-407b-bafe-a3a07dee4ebf">

As we see, the file is read properly and can be used on the app

This should only apply to android devices, the emulator uses API 33, Android 13.0 Tiramisu

<img width="1440" alt="image" src="https://github.com/rnmods/react-native-document-picker/assets/32473673/b0153c1f-2fce-453b-853a-0aa696ed3d08">

I run yarn typescript with 0 issues

<img width="849" alt="image" src="https://github.com/rnmods/react-native-document-picker/assets/32473673/5baa5901-1338-4d3f-a17d-3e21c9379822">

Here is the differences between my branch and main

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
