### PR TITLE
fix(android): path traversal vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # react-native-document-picker
 
+📣📣 A full rewrite of the library is in progress. 📣📣
+
+Please subscribe to [this issue](https://github.com/rnmods/react-native-document-picker/issues/603) to receive updates.
+
 🚧🚧 GH discussions available 🚧🚧
 
 If you want to ask questions, we opened [GH discussions](https://github.com/rnmods/react-native-document-picker/discussions) for that purpose! 🤗 Issue tracker is now reserved for bugs and feature requests only and issues not following the issue template can be closed. Thank you!

--- a/android/src/main/java/com/reactnativedocumentpicker/RNDocumentPickerModule.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/RNDocumentPickerModule.java
@@ -316,7 +316,7 @@ public class RNDocumentPickerModule extends NativeDocumentPickerSpec {
         if (fileName == null) {
           fileName = String.valueOf(System.currentTimeMillis());
         }
-        File destFile = new File(dir, fileName);
+        File destFile = safeGetDestination(new File(dir, fileName), dir.getCanonicalPath());
         Uri copyPath = copyFile(context, uri, destFile);
         map.putString(FIELD_FILE_COPY_URI, copyPath.toString());
       } catch (Exception e) {
@@ -324,6 +324,14 @@ public class RNDocumentPickerModule extends NativeDocumentPickerSpec {
         map.putNull(FIELD_FILE_COPY_URI);
         map.putString(FIELD_COPY_ERROR, e.getLocalizedMessage());
       }
+    }
+
+    public File safeGetDestination(File destFile, String expectedDir) throws IllegalArgumentException, IOException {
+      String canonicalPath = destFile.getCanonicalPath();
+      if (!canonicalPath.startsWith(expectedDir)) {
+        throw new IllegalArgumentException("The copied file is attempting to write outside of the target directory.");
+      }
+      return destFile;
     }
 
     public static Uri copyFile(Context context, Uri uri, File destFile) throws IOException {


### PR DESCRIPTION
# Summary

This fixes a Path Traversal Vulnerability which was present on Android [https://developer.android.com/privacy-and-security/risks/path-traversal](https://developer.android.com/privacy-and-security/risks/path-traversal).

According to CVSS spec, this is a high severity vulnerability [see here](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:H/A:H). 

The prerequisite is that the user has a malicious app installed on their phone that they can pick files from (think Google Drive or Dropbox, or some File browser app, which is malicious), and that the `copyTo` option is passed to the picking functions.

What could happen is that the `fileName` obtained from a [`Cursor`](https://developer.android.com/reference/android/database/Cursor) when picking a file using the malicious' app [`DocumentProvider`](https://developer.android.com/reference/android/provider/DocumentsProvider) could contain special characters such as `../` which would change the destination that the file is being written to when using the `copyTo` option.

This can, generally speaking, lead to files being rewritten. In the context of React Native, this could lead to the js bundle of the application being swapped for another one, if user used picked a malicious file from a malicious `DocumentProvider`, and the `copyTo` option is specified.

## Test Plan

I tested the fix on a Android 10 device and Android 14 simulator. The fix for the issue follows the fix from the [recommended mitigation](https://developer.android.com/privacy-and-security/risks/path-traversal#mitigations).


### What are the steps to reproduce (after prerequisites)?

Given a device or emulator, if you modify the first param passed to `safeGetDestination` to lead to a path outside of the `cacheDir` or `FilesDir`, `copyFileToLocalStorage` will not perform the copy the because `safeGetDestination` throws a `IllegalArgumentException`.


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
